### PR TITLE
Correct root certificate check.

### DIFF
--- a/server/src/main/java/com/android/example/KeyAttestationExample.java
+++ b/server/src/main/java/com/android/example/KeyAttestationExample.java
@@ -241,7 +241,8 @@ public class KeyAttestationExample {
                 .generateCertificate(
                     new ByteArrayInputStream(GOOGLE_ROOT_CERTIFICATE.getBytes(UTF_8)));
     if (Arrays.equals(
-        secureRoot.getTBSCertificate(), certs[certs.length - 1].getTBSCertificate())) {
+        secureRoot.getPublicKey().getEncoded(),
+        certs[certs.length - 1].getPublicKey().getEncoded())) {
       System.out.println(
           "The root certificate is correct, so this attestation is trustworthy, as long as none of"
               + " the certificates in the chain have been revoked. A production-level system"


### PR DESCRIPTION
The test that the root certificate matches the Google root should
check that the public keys match, rather than doing a bytewise
comparison of the entire certificate contents.  This allows the
certificate to be updated (which has been done once) without breaking
the comparison, as long as the public key remains the same.

Note that it's safe to check only the public key because the chain of
signatures has already been checked.