### PR TITLE
- Added another missing Google Hardware Attestation Root certificate

### DIFF
--- a/server/src/main/java/com/android/example/KeyAttestationExample.java
+++ b/server/src/main/java/com/android/example/KeyAttestationExample.java
@@ -16,6 +16,7 @@
 package com.android.example;
 
 import static com.google.android.attestation.Constants.GOOGLE_ROOT_CERTIFICATE;
+import static com.google.android.attestation.Constants.GOOGLE_ROOT_CERTIFICATE_2;
 import static com.google.android.attestation.ParsedAttestationRecord.createParsedAttestationRecord;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
@@ -25,6 +26,7 @@ import com.google.android.attestation.CertificateRevocationStatus;
 import com.google.android.attestation.AuthorizationList;
 import com.google.android.attestation.ParsedAttestationRecord;
 import com.google.android.attestation.RootOfTrust;
+
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -42,6 +44,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+
 import org.bouncycastle.util.encoders.Base64;
 
 /**
@@ -68,211 +71,227 @@ import org.bouncycastle.util.encoders.Base64;
  * <p>4. Extracting the attestation extension data from the attestation certificate.
  *
  * <p>5. Verifying (and printing) several important data elements from the attestation extension.
- *
  */
 @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
 public class KeyAttestationExample {
 
-  private KeyAttestationExample() {}
-
-  public static void main(String[] args)
-      throws CertificateException, IOException, NoSuchProviderException, NoSuchAlgorithmException,
-          InvalidKeyException, SignatureException {
-    X509Certificate[] certs;
-    if (args.length == 1) {
-      String certFilesDir = args[0];
-      certs = loadCertificates(certFilesDir);
-    } else {
-      throw new IOException("Expected path to a directory containing certificates as an argument.");
+    private KeyAttestationExample() {
     }
 
-    verifyCertificateChain(certs);
-
-    ParsedAttestationRecord parsedAttestationRecord = createParsedAttestationRecord(certs[0]);
-
-    System.out.println("Attestation version: " + parsedAttestationRecord.attestationVersion);
-    System.out.println(
-        "Attestation Security Level: " + parsedAttestationRecord.attestationSecurityLevel.name());
-    System.out.println("Keymaster Version: " + parsedAttestationRecord.keymasterVersion);
-    System.out.println(
-        "Keymaster Security Level: " + parsedAttestationRecord.keymasterSecurityLevel.name());
-
-    System.out.println(
-        "Attestation Challenge: "
-            + new String(parsedAttestationRecord.attestationChallenge, UTF_8));
-    System.out.println("Unique ID: " + Arrays.toString(parsedAttestationRecord.uniqueId));
-
-    System.out.println("Software Enforced Authorization List:");
-    AuthorizationList softwareEnforced = parsedAttestationRecord.softwareEnforced;
-    printAuthorizationList(softwareEnforced, "\t");
-
-    System.out.println("TEE Enforced Authorization List:");
-    AuthorizationList teeEnforced = parsedAttestationRecord.teeEnforced;
-    printAuthorizationList(teeEnforced, "\t");
-  }
-
-  private static void printAuthorizationList(AuthorizationList authorizationList, String indent) {
-    // Detailed explanation of the keys and their values can be found here:
-    // https://source.android.com/security/keystore/tags
-    printOptional(authorizationList.purpose, indent + "Purpose(s)");
-    printOptional(authorizationList.algorithm, indent + "Algorithm");
-    printOptional(authorizationList.keySize, indent + "Key Size");
-    printOptional(authorizationList.digest, indent + "Digest");
-    printOptional(authorizationList.padding, indent + "Padding");
-    printOptional(authorizationList.ecCurve, indent + "EC Curve");
-    printOptional(authorizationList.rsaPublicExponent, indent + "RSA Public Exponent");
-    System.out.println(indent + "Rollback Resistance: " + authorizationList.rollbackResistance);
-    printOptional(authorizationList.activeDateTime, indent + "Active DateTime");
-    printOptional(
-        authorizationList.originationExpireDateTime, indent + "Origination Expire DateTime");
-    printOptional(authorizationList.usageExpireDateTime, indent + "Usage Expire DateTime");
-    System.out.println(indent + "No Auth Required: " + authorizationList.noAuthRequired);
-    printOptional(authorizationList.userAuthType, indent + "User Auth Type");
-    printOptional(authorizationList.authTimeout, indent + "Auth Timeout");
-    System.out.println(indent + "Allow While On Body: " + authorizationList.allowWhileOnBody);
-    System.out.println(
-        indent
-            + "Trusted User Presence Required: "
-            + authorizationList.trustedUserPresenceRequired);
-    System.out.println(
-        indent + "Trusted Confirmation Required: " + authorizationList.trustedConfirmationRequired);
-    System.out.println(
-        indent + "Unlocked Device Required: " + authorizationList.unlockedDeviceRequired);
-    System.out.println(indent + "All Applications: " + authorizationList.allApplications);
-    printOptional(authorizationList.applicationId, indent + "Application ID");
-    printOptional(authorizationList.creationDateTime, indent + "Creation DateTime");
-    printOptional(authorizationList.origin, indent + "Origin");
-    System.out.println(indent + "Rollback Resistant: " + authorizationList.rollbackResistant);
-    if (authorizationList.rootOfTrust.isPresent()) {
-      System.out.println(indent + "Root Of Trust:");
-      printRootOfTrust(authorizationList.rootOfTrust, indent + "\t");
-    }
-    printOptional(authorizationList.osVersion, indent + "OS Version");
-    printOptional(authorizationList.osPatchLevel, indent + "OS Patch Level");
-    if (authorizationList.attestationApplicationId.isPresent()) {
-      System.out.println(indent + "Attestation Application ID:");
-      printAttestationApplicationId(authorizationList.attestationApplicationId, indent + "\t");
-    }
-    printOptional(
-        authorizationList.attestationApplicationIdBytes,
-        indent + "Attestation Application ID Bytes");
-    printOptional(authorizationList.attestationIdBrand, indent + "Attestation ID Brand");
-    printOptional(authorizationList.attestationIdDevice, indent + "Attestation ID Device");
-    printOptional(authorizationList.attestationIdProduct, indent + "Attestation ID Product");
-    printOptional(authorizationList.attestationIdSerial, indent + "Attestation ID Serial");
-    printOptional(authorizationList.attestationIdImei, indent + "Attestation ID IMEI");
-    printOptional(authorizationList.attestationIdMeid, indent + "Attestation ID MEID");
-    printOptional(
-        authorizationList.attestationIdManufacturer, indent + "Attestation ID Manufacturer");
-    printOptional(authorizationList.attestationIdModel, indent + "Attestation ID Model");
-    printOptional(authorizationList.vendorPatchLevel, indent + "Vendor Patch Level");
-    printOptional(authorizationList.bootPatchLevel, indent + "Boot Patch Level");
-  }
-
-  private static void printRootOfTrust(Optional<RootOfTrust> rootOfTrust, String indent) {
-    if (rootOfTrust.isPresent()) {
-      System.out.println(
-          indent
-              + "Verified Boot Key: "
-              + Base64.toBase64String(rootOfTrust.get().verifiedBootKey));
-      System.out.println(indent + "Device Locked: " + rootOfTrust.get().deviceLocked);
-      System.out.println(
-          indent + "Verified Boot State: " + rootOfTrust.get().verifiedBootState.name());
-      System.out.println(
-          indent
-              + "Verified Boot Hash: "
-              + Base64.toBase64String(rootOfTrust.get().verifiedBootHash));
-    }
-  }
-
-  private static void printAttestationApplicationId(
-      Optional<AttestationApplicationId> attestationApplicationId, String indent) {
-    if (attestationApplicationId.isPresent()) {
-      System.out.println(indent + "Package Infos (<package name>, <version>): ");
-      for (AttestationPackageInfo info : attestationApplicationId.get().packageInfos) {
-        System.out.println(indent + "\t" + info.packageName + ", " + info.version);
-      }
-      System.out.println(indent + "Signature Digests:");
-      for (byte[] digest : attestationApplicationId.get().signatureDigests) {
-        System.out.println(indent + "\t" + Base64.toBase64String(digest));
-      }
-    }
-  }
-
-  private static <T> void printOptional(Optional<T> optional, String caption) {
-    if (optional.isPresent()) {
-      if (optional.get() instanceof byte[]) {
-        System.out.println(caption + ": " + Base64.toBase64String((byte[]) optional.get()));
-      } else {
-        System.out.println(caption + ": " + optional.get());
-      }
-    }
-  }
-
-  private static void verifyCertificateChain(X509Certificate[] certs)
-      throws CertificateException, NoSuchAlgorithmException, InvalidKeyException,
-      NoSuchProviderException, SignatureException, IOException {
-    X509Certificate parent = certs[certs.length - 1];
-    for (int i = certs.length - 1; i >= 0; i--) {
-      X509Certificate cert = certs[i];
-      // Verify that the certificate has not expired.
-      cert.checkValidity();
-      cert.verify(parent.getPublicKey());
-      parent = cert;
-      try {
-        CertificateRevocationStatus certStatus = CertificateRevocationStatus
-            .fetchStatus(cert.getSerialNumber());
-        if (certStatus != null) {
-          throw new CertificateException(
-              "Certificate revocation status is " + certStatus.status.name());
+    public static void main(String[] args)
+            throws CertificateException, IOException, NoSuchProviderException, NoSuchAlgorithmException,
+            InvalidKeyException, SignatureException {
+        X509Certificate[] certs;
+        if (args.length == 1) {
+            String certFilesDir = args[0];
+            certs = loadCertificates(certFilesDir);
+        } else {
+            throw new IOException("Expected path to a directory containing certificates as an argument.");
         }
-      } catch (IOException e) {
-        throw new IOException("Unable to fetch certificate status. Check connectivity.");
-      }
+
+        verifyCertificateChain(certs);
+
+        ParsedAttestationRecord parsedAttestationRecord = createParsedAttestationRecord(certs[0]);
+
+        System.out.println("Attestation version: " + parsedAttestationRecord.attestationVersion);
+        System.out.println(
+                "Attestation Security Level: " + parsedAttestationRecord.attestationSecurityLevel.name());
+        System.out.println("Keymaster Version: " + parsedAttestationRecord.keymasterVersion);
+        System.out.println(
+                "Keymaster Security Level: " + parsedAttestationRecord.keymasterSecurityLevel.name());
+
+        System.out.println(
+                "Attestation Challenge: "
+                        + new String(parsedAttestationRecord.attestationChallenge, UTF_8));
+        System.out.println("Unique ID: " + Arrays.toString(parsedAttestationRecord.uniqueId));
+
+        System.out.println("Software Enforced Authorization List:");
+        AuthorizationList softwareEnforced = parsedAttestationRecord.softwareEnforced;
+        printAuthorizationList(softwareEnforced, "\t");
+
+        System.out.println("TEE Enforced Authorization List:");
+        AuthorizationList teeEnforced = parsedAttestationRecord.teeEnforced;
+        printAuthorizationList(teeEnforced, "\t");
     }
 
-    // If the attestation is trustworthy and the device ships with hardware-
-    // level key attestation, Android 7.0 (API level 24) or higher, and
-    // Google Play services, the root certificate should be signed with the
-    // Google attestation root key.
-    X509Certificate secureRoot =
-        (X509Certificate)
-            CertificateFactory.getInstance("X.509")
-                .generateCertificate(
-                    new ByteArrayInputStream(GOOGLE_ROOT_CERTIFICATE.getBytes(UTF_8)));
-    if (Arrays.equals(
-        secureRoot.getPublicKey().getEncoded(),
-        certs[certs.length - 1].getPublicKey().getEncoded())) {
-      System.out.println(
-          "The root certificate is correct, so this attestation is trustworthy, as long as none of"
-              + " the certificates in the chain have been revoked. A production-level system"
-              + " should check the certificate revocation lists using the distribution points that"
-              + " are listed in the intermediate and root certificates.");
-    } else {
-      System.out.println(
-          "The root certificate is NOT correct. The attestation was probably generated by"
-              + " software, not in secure hardware. This means that, although the attestation"
-              + " contents are probably valid and correct, there is no proof that they are in fact"
-              + " correct. If you're using a production-level system, you should now treat the"
-              + " properties of this attestation certificate as advisory only, and you shouldn't"
-              + " rely on this attestation certificate to provide security guarantees.");
+    private static void printAuthorizationList(AuthorizationList authorizationList, String indent) {
+        // Detailed explanation of the keys and their values can be found here:
+        // https://source.android.com/security/keystore/tags
+        printOptional(authorizationList.purpose, indent + "Purpose(s)");
+        printOptional(authorizationList.algorithm, indent + "Algorithm");
+        printOptional(authorizationList.keySize, indent + "Key Size");
+        printOptional(authorizationList.digest, indent + "Digest");
+        printOptional(authorizationList.padding, indent + "Padding");
+        printOptional(authorizationList.ecCurve, indent + "EC Curve");
+        printOptional(authorizationList.rsaPublicExponent, indent + "RSA Public Exponent");
+        System.out.println(indent + "Rollback Resistance: " + authorizationList.rollbackResistance);
+        printOptional(authorizationList.activeDateTime, indent + "Active DateTime");
+        printOptional(
+                authorizationList.originationExpireDateTime, indent + "Origination Expire DateTime");
+        printOptional(authorizationList.usageExpireDateTime, indent + "Usage Expire DateTime");
+        System.out.println(indent + "No Auth Required: " + authorizationList.noAuthRequired);
+        printOptional(authorizationList.userAuthType, indent + "User Auth Type");
+        printOptional(authorizationList.authTimeout, indent + "Auth Timeout");
+        System.out.println(indent + "Allow While On Body: " + authorizationList.allowWhileOnBody);
+        System.out.println(
+                indent
+                        + "Trusted User Presence Required: "
+                        + authorizationList.trustedUserPresenceRequired);
+        System.out.println(
+                indent + "Trusted Confirmation Required: " + authorizationList.trustedConfirmationRequired);
+        System.out.println(
+                indent + "Unlocked Device Required: " + authorizationList.unlockedDeviceRequired);
+        System.out.println(indent + "All Applications: " + authorizationList.allApplications);
+        printOptional(authorizationList.applicationId, indent + "Application ID");
+        printOptional(authorizationList.creationDateTime, indent + "Creation DateTime");
+        printOptional(authorizationList.origin, indent + "Origin");
+        System.out.println(indent + "Rollback Resistant: " + authorizationList.rollbackResistant);
+        if (authorizationList.rootOfTrust.isPresent()) {
+            System.out.println(indent + "Root Of Trust:");
+            printRootOfTrust(authorizationList.rootOfTrust, indent + "\t");
+        }
+        printOptional(authorizationList.osVersion, indent + "OS Version");
+        printOptional(authorizationList.osPatchLevel, indent + "OS Patch Level");
+        if (authorizationList.attestationApplicationId.isPresent()) {
+            System.out.println(indent + "Attestation Application ID:");
+            printAttestationApplicationId(authorizationList.attestationApplicationId, indent + "\t");
+        }
+        printOptional(
+                authorizationList.attestationApplicationIdBytes,
+                indent + "Attestation Application ID Bytes");
+        printOptional(authorizationList.attestationIdBrand, indent + "Attestation ID Brand");
+        printOptional(authorizationList.attestationIdDevice, indent + "Attestation ID Device");
+        printOptional(authorizationList.attestationIdProduct, indent + "Attestation ID Product");
+        printOptional(authorizationList.attestationIdSerial, indent + "Attestation ID Serial");
+        printOptional(authorizationList.attestationIdImei, indent + "Attestation ID IMEI");
+        printOptional(authorizationList.attestationIdMeid, indent + "Attestation ID MEID");
+        printOptional(
+                authorizationList.attestationIdManufacturer, indent + "Attestation ID Manufacturer");
+        printOptional(authorizationList.attestationIdModel, indent + "Attestation ID Model");
+        printOptional(authorizationList.vendorPatchLevel, indent + "Vendor Patch Level");
+        printOptional(authorizationList.bootPatchLevel, indent + "Boot Patch Level");
     }
-  }
 
-  private static X509Certificate[] loadCertificates(String certFilesDir)
-      throws CertificateException, IOException {
-    // Load the attestation certificates from the directory in alphabetic order.
-    List<Path> records;
-    try (Stream<Path> pathStream = Files.walk(Paths.get(certFilesDir))) {
-      records = pathStream.filter(Files::isRegularFile).sorted().collect(Collectors.toList());
+    private static void printRootOfTrust(Optional<RootOfTrust> rootOfTrust, String indent) {
+        if (rootOfTrust.isPresent()) {
+            System.out.println(
+                    indent
+                            + "Verified Boot Key: "
+                            + Base64.toBase64String(rootOfTrust.get().verifiedBootKey));
+            System.out.println(indent + "Device Locked: " + rootOfTrust.get().deviceLocked);
+            System.out.println(
+                    indent + "Verified Boot State: " + rootOfTrust.get().verifiedBootState.name());
+            System.out.println(
+                    indent
+                            + "Verified Boot Hash: "
+                            + Base64.toBase64String(rootOfTrust.get().verifiedBootHash));
+        }
     }
-    X509Certificate[] certs = new X509Certificate[records.size()];
-    CertificateFactory factory = CertificateFactory.getInstance("X.509");
-    for (int i = 0; i < records.size(); ++i) {
-      byte[] encodedCert = Files.readAllBytes(records.get(i));
-      ByteArrayInputStream inputStream = new ByteArrayInputStream(encodedCert);
-      certs[i] = (X509Certificate) factory.generateCertificate(inputStream);
+
+    private static void printAttestationApplicationId(
+            Optional<AttestationApplicationId> attestationApplicationId, String indent) {
+        if (attestationApplicationId.isPresent()) {
+            System.out.println(indent + "Package Infos (<package name>, <version>): ");
+            for (AttestationPackageInfo info : attestationApplicationId.get().packageInfos) {
+                System.out.println(indent + "\t" + info.packageName + ", " + info.version);
+            }
+            System.out.println(indent + "Signature Digests:");
+            for (byte[] digest : attestationApplicationId.get().signatureDigests) {
+                System.out.println(indent + "\t" + Base64.toBase64String(digest));
+            }
+        }
     }
-    return certs;
-  }
+
+    private static <T> void printOptional(Optional<T> optional, String caption) {
+        if (optional.isPresent()) {
+            if (optional.get() instanceof byte[]) {
+                System.out.println(caption + ": " + Base64.toBase64String((byte[]) optional.get()));
+            } else {
+                System.out.println(caption + ": " + optional.get());
+            }
+        }
+    }
+
+    private static void verifyCertificateChain(X509Certificate[] certs)
+            throws CertificateException, NoSuchAlgorithmException, InvalidKeyException,
+            NoSuchProviderException, SignatureException, IOException {
+        X509Certificate parent = certs[certs.length - 1];
+        for (int i = certs.length - 1; i >= 0; i--) {
+            X509Certificate cert = certs[i];
+            // Verify that the certificate has not expired.
+            cert.checkValidity();
+            cert.verify(parent.getPublicKey());
+            parent = cert;
+            try {
+                CertificateRevocationStatus certStatus = CertificateRevocationStatus
+                        .fetchStatus(cert.getSerialNumber());
+                if (certStatus != null) {
+                    throw new CertificateException(
+                            "Certificate revocation status is " + certStatus.status.name());
+                }
+            } catch (IOException e) {
+                throw new IOException("Unable to fetch certificate status. Check connectivity.");
+            }
+        }
+
+        // If the attestation is trustworthy and the device ships with hardware-
+        // level key attestation, Android 7.0 (API level 24) or higher, and
+        // Google Play services, the root certificate should be signed with the
+        // Google attestation root key.
+        X509Certificate secureRoot =
+                (X509Certificate)
+                        CertificateFactory.getInstance("X.509")
+                                .generateCertificate(
+                                        new ByteArrayInputStream(GOOGLE_ROOT_CERTIFICATE.getBytes(UTF_8)));
+        if (Arrays.equals(
+                secureRoot.getPublicKey().getEncoded(),
+                certs[certs.length - 1].getPublicKey().getEncoded())) {
+            System.out.println(
+                    "The root certificate is correct, so this attestation is trustworthy, as long as none of"
+                            + " the certificates in the chain have been revoked. A production-level system"
+                            + " should check the certificate revocation lists using the distribution points that"
+                            + " are listed in the intermediate and root certificates.");
+        } else {
+
+            secureRoot =
+                    (X509Certificate)
+                            CertificateFactory.getInstance("X.509")
+                                    .generateCertificate(
+                                            new ByteArrayInputStream(GOOGLE_ROOT_CERTIFICATE_2.getBytes(UTF_8)));
+            if (Arrays.equals(
+                    secureRoot.getPublicKey().getEncoded(),
+                    certs[certs.length - 1].getPublicKey().getEncoded())) {
+                System.out.println(
+                        "The root certificate is correct, so this attestation is trustworthy, as long as none of"
+                                + " the certificates in the chain have been revoked. A production-level system"
+                                + " should check the certificate revocation lists using the distribution points that"
+                                + " are listed in the intermediate and root certificates.");
+            } else {
+                System.out.println(
+                        "The root certificate is NOT correct. The attestation was probably generated by"
+                                + " software, not in secure hardware. This means that, although the attestation"
+                                + " contents are probably valid and correct, there is no proof that they are in fact"
+                                + " correct. If you're using a production-level system, you should now treat the"
+                                + " properties of this attestation certificate as advisory only, and you shouldn't"
+                                + " rely on this attestation certificate to provide security guarantees.");
+            }
+        }
+    }
+
+    private static X509Certificate[] loadCertificates(String certFilesDir)
+            throws CertificateException, IOException {
+        // Load the attestation certificates from the directory in alphabetic order.
+        List<Path> records;
+        try (Stream<Path> pathStream = Files.walk(Paths.get(certFilesDir))) {
+            records = pathStream.filter(Files::isRegularFile).sorted().collect(Collectors.toList());
+        }
+        X509Certificate[] certs = new X509Certificate[records.size()];
+        CertificateFactory factory = CertificateFactory.getInstance("X.509");
+        for (int i = 0; i < records.size(); ++i) {
+            byte[] encodedCert = Files.readAllBytes(records.get(i));
+            ByteArrayInputStream inputStream = new ByteArrayInputStream(encodedCert);
+            certs[i] = (X509Certificate) factory.generateCertificate(inputStream);
+        }
+        return certs;
+    }
 }

--- a/server/src/main/java/com/google/android/attestation/Constants.java
+++ b/server/src/main/java/com/google/android/attestation/Constants.java
@@ -54,6 +54,37 @@ public class Constants {
           + "MDSXYrB4I4WHXPGjxhZuCuPBLTdOLU8YRvMYdEvYebWHMpvwGCF6bAx3JBpIeOQ1"
           + "wDB5y0USicV3YgYGmi+NZfhA4URSh77Yd6uuJOJENRaNVTzk\n"
           + "-----END CERTIFICATE-----";
+  static final String GOOGLE_ROOT_CERTIFICATE_2 =
+          "-----BEGIN CERTIFICATE-----\n" +
+          "MIIFHDCCAwSgAwIBAgIJANUP8luj8tazMA0GCSqGSIb3DQEBCwUAMBsxGTAXBgNV\n" +
+          "BAUTEGY5MjAwOWU4NTNiNmIwNDUwHhcNMTkxMTIyMjAzNzU4WhcNMzQxMTE4MjAz\n" +
+          "NzU4WjAbMRkwFwYDVQQFExBmOTIwMDllODUzYjZiMDQ1MIICIjANBgkqhkiG9w0B\n" +
+          "AQEFAAOCAg8AMIICCgKCAgEAr7bHgiuxpwHsK7Qui8xUFmOr75gvMsd/dTEDDJdS\n" +
+          "Sxtf6An7xyqpRR90PL2abxM1dEqlXnf2tqw1Ne4Xwl5jlRfdnJLmN0pTy/4lj4/7\n" +
+          "tv0Sk3iiKkypnEUtR6WfMgH0QZfKHM1+di+y9TFRtv6y//0rb+T+W8a9nsNL/ggj\n" +
+          "nar86461qO0rOs2cXjp3kOG1FEJ5MVmFmBGtnrKpa73XpXyTqRxB/M0n1n/W9nGq\n" +
+          "C4FSYa04T6N5RIZGBN2z2MT5IKGbFlbC8UrW0DxW7AYImQQcHtGl/m00QLVWutHQ\n" +
+          "oVJYnFPlXTcHYvASLu+RhhsbDmxMgJJ0mcDpvsC4PjvB+TxywElgS70vE0XmLD+O\n" +
+          "JtvsBslHZvPBKCOdT0MS+tgSOIfga+z1Z1g7+DVagf7quvmag8jfPioyKvxnK/Eg\n" +
+          "sTUVi2ghzq8wm27ud/mIM7AY2qEORR8Go3TVB4HzWQgpZrt3i5MIlCaY504LzSRi\n" +
+          "igHCzAPlHws+W0rB5N+er5/2pJKnfBSDiCiFAVtCLOZ7gLiMm0jhO2B6tUXHI/+M\n" +
+          "RPjy02i59lINMRRev56GKtcd9qO/0kUJWdZTdA2XoS82ixPvZtXQpUpuL12ab+9E\n" +
+          "aDK8Z4RHJYYfCT3Q5vNAXaiWQ+8PTWm2QgBR/bkwSWc+NpUFgNPN9PvQi8WEg5Um\n" +
+          "AGMCAwEAAaNjMGEwHQYDVR0OBBYEFDZh4QB8iAUJUYtEbEf/GkzJ6k8SMB8GA1Ud\n" +
+          "IwQYMBaAFDZh4QB8iAUJUYtEbEf/GkzJ6k8SMA8GA1UdEwEB/wQFMAMBAf8wDgYD\n" +
+          "VR0PAQH/BAQDAgIEMA0GCSqGSIb3DQEBCwUAA4ICAQBOMaBc8oumXb2voc7XCWnu\n" +
+          "XKhBBK3e2KMGz39t7lA3XXRe2ZLLAkLM5y3J7tURkf5a1SutfdOyXAmeE6SRo83U\n" +
+          "h6WszodmMkxK5GM4JGrnt4pBisu5igXEydaW7qq2CdC6DOGjG+mEkN8/TA6p3cno\n" +
+          "L/sPyz6evdjLlSeJ8rFBH6xWyIZCbrcpYEJzXaUOEaxxXxgYz5/cTiVKN2M1G2ok\n" +
+          "QBUIYSY6bjEL4aUN5cfo7ogP3UvliEo3Eo0YgwuzR2v0KR6C1cZqZJSTnghIC/vA\n" +
+          "D32KdNQ+c3N+vl2OTsUVMC1GiWkngNx1OO1+kXW+YTnnTUOtOIswUP/Vqd5SYgAI\n" +
+          "mMAfY8U9/iIgkQj6T2W6FsScy94IN9fFhE1UtzmLoBIuUFsVXJMTz+Jucth+IqoW\n" +
+          "Fua9v1R93/k98p41pjtFX+H8DslVgfP097vju4KDlqN64xV1grw3ZLl4CiOe/A91\n" +
+          "oeLm2UHOq6wn3esB4r2EIQKb6jTVGu5sYCcdWpXr0AUVqcABPdgL+H7qJguBw09o\n" +
+          "jm6xNIrw2OocrDKsudk/okr/AwqEyPKw9WnMlQgLIKw1rODG2NvU9oR3GVGdMkUB\n" +
+          "ZutL8VuFkERQGt6vQ2OCw0sV47VMkuYbacK/xyZFiRcrPJPb41zgbQj9XAEyLKCH\n" +
+          "ex0SdDrx+tWUDqG8At2JHA==\n" +
+          "-----END CERTIFICATE-----";
   static final String KEY_DESCRIPTION_OID = "1.3.6.1.4.1.11129.2.1.17";
   static final int ATTESTATION_VERSION_INDEX = 0;
   static final int ATTESTATION_SECURITY_LEVEL_INDEX = 1;


### PR DESCRIPTION
The code base had one Google root certificate that might have been used to sign the root
certificate in a real attestation certificate chain from some compliant devices. Some devices will fail this check because there are two certs which are used to sign the root cert.

More details :
https://developer.android.com/training/articles/security-key-attestation