### PR TITLE
Change UserAuthType to Set of Enum

### DIFF
--- a/server/src/main/java/com/google/android/attestation/AuthorizationList.java
+++ b/server/src/main/java/com/google/android/attestation/AuthorizationList.java
@@ -292,19 +292,20 @@ public class AuthorizationList {
 
   // Visible for testing.
   static Set<UserAuthType> userAuthTypeToEnum(long userAuthType) {
-    Set<UserAuthType> result = new HashSet<>();
     if (userAuthType == 0) {
-      result.add(USER_AUTH_TYPE_NONE);
-    } else {
-      if ((userAuthType & 1L) == 1L) {
-        result.add(PASSWORD);
-      }
-      if ((userAuthType & 2L) == 2L) {
-        result.add(FINGERPRINT);
-      }
-      if (userAuthType == UINT32_MAX) {
-        result.add(USER_AUTH_TYPE_ANY);
-      }
+      return Set.of(USER_AUTH_TYPE_NONE);
+    }
+
+    Set<UserAuthType> result = new HashSet<>();
+
+    if ((userAuthType & 1L) == 1L) {
+      result.add(PASSWORD);
+    }
+    if ((userAuthType & 2L) == 2L) {
+      result.add(FINGERPRINT);
+    }
+    if (userAuthType == UINT32_MAX) {
+      result.add(USER_AUTH_TYPE_ANY);
     }
 
     if (result.isEmpty()) {

--- a/server/src/test/java/com/google/android/attestation/AuthorizationListTest.java
+++ b/server/src/test/java/com/google/android/attestation/AuthorizationListTest.java
@@ -28,6 +28,10 @@ import static org.junit.Assert.fail;
 import com.google.common.collect.ImmutableSet;
 import java.io.IOException;
 import java.time.Instant;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+
 import org.bouncycastle.asn1.ASN1Encodable;
 import org.bouncycastle.asn1.ASN1Sequence;
 import org.bouncycastle.util.encoders.Base64;
@@ -136,13 +140,17 @@ public class AuthorizationListTest {
 
   @Test
   public void testUserAuthTypeToEnum() {
-    assertThat(userAuthTypeToEnum(0L)).isEqualTo(USER_AUTH_TYPE_NONE);
-    assertThat(userAuthTypeToEnum(1L)).isEqualTo(PASSWORD);
-    assertThat(userAuthTypeToEnum(2L)).isEqualTo(FINGERPRINT);
-    assertThat(userAuthTypeToEnum(UINT32_MAX)).isEqualTo(USER_AUTH_TYPE_ANY);
+    assertThat(userAuthTypeToEnum(0L)).isEqualTo(Collections.singleton(USER_AUTH_TYPE_NONE));
+    assertThat(userAuthTypeToEnum(1L)).isEqualTo(Collections.singleton(PASSWORD));
+    assertThat(userAuthTypeToEnum(2L)).isEqualTo(Collections.singleton(FINGERPRINT));
+    assertThat(userAuthTypeToEnum(3L)).isEqualTo(new HashSet<>(Arrays.asList(PASSWORD, FINGERPRINT)));
+    assertThat(userAuthTypeToEnum(UINT32_MAX)).isEqualTo(
+        new HashSet<>(Arrays.asList(PASSWORD, FINGERPRINT, USER_AUTH_TYPE_ANY))
+    );
+
 
     try {
-      userAuthTypeToEnum(3L);
+      userAuthTypeToEnum(4L);
       fail();
     } catch (IllegalArgumentException expected) {
       assertThat(expected).hasMessageThat().contains("Invalid User Auth Type.");

--- a/server/src/test/java/com/google/android/attestation/AuthorizationListTest.java
+++ b/server/src/test/java/com/google/android/attestation/AuthorizationListTest.java
@@ -28,9 +28,7 @@ import static org.junit.Assert.fail;
 import com.google.common.collect.ImmutableSet;
 import java.io.IOException;
 import java.time.Instant;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashSet;
+import java.util.Set;
 
 import org.bouncycastle.asn1.ASN1Encodable;
 import org.bouncycastle.asn1.ASN1Sequence;
@@ -140,13 +138,11 @@ public class AuthorizationListTest {
 
   @Test
   public void testUserAuthTypeToEnum() {
-    assertThat(userAuthTypeToEnum(0L)).isEqualTo(Collections.singleton(USER_AUTH_TYPE_NONE));
-    assertThat(userAuthTypeToEnum(1L)).isEqualTo(Collections.singleton(PASSWORD));
-    assertThat(userAuthTypeToEnum(2L)).isEqualTo(Collections.singleton(FINGERPRINT));
-    assertThat(userAuthTypeToEnum(3L)).isEqualTo(new HashSet<>(Arrays.asList(PASSWORD, FINGERPRINT)));
-    assertThat(userAuthTypeToEnum(UINT32_MAX)).isEqualTo(
-        new HashSet<>(Arrays.asList(PASSWORD, FINGERPRINT, USER_AUTH_TYPE_ANY))
-    );
+    assertThat(userAuthTypeToEnum(0L)).isEqualTo(Set.of(USER_AUTH_TYPE_NONE));
+    assertThat(userAuthTypeToEnum(1L)).isEqualTo(Set.of(PASSWORD));
+    assertThat(userAuthTypeToEnum(2L)).isEqualTo(Set.of(FINGERPRINT));
+    assertThat(userAuthTypeToEnum(3L)).isEqualTo(Set.of(PASSWORD, FINGERPRINT));
+    assertThat(userAuthTypeToEnum(UINT32_MAX)).isEqualTo(Set.of(PASSWORD, FINGERPRINT, USER_AUTH_TYPE_ANY));
 
 
     try {


### PR DESCRIPTION
The `USER_AUTH_TYPE` tag defines a 32-bit integer bitmask with the types
of user authenticators that may be used to authorize a key [1]. That
means, the value for the tag can define a single authenticator but
also multiple authenticators.

The implementation so far only permitted values which defined exactly
one flag and would throw an `IllegalArgumentException` otherwise.

This commit changes the type of `AuthorizationList.userAuthType` from
`UserAuthType` to `Set<UserAuthType>`. That way, a value of `3` for
the `USER_AUTH_TYPE` tag evaluates to `(PASSWORD, FINGERPRINT)` instead
of raising an exception.

[1] https://source.android.com/security/keystore/tags#user_auth_type