### PR TITLE
Dump the value of Tag::IDENTITY_CREDENTIAL_KEY.

### DIFF
--- a/server/src/main/java/com/android/example/KeyAttestationExample.java
+++ b/server/src/main/java/com/android/example/KeyAttestationExample.java
@@ -167,6 +167,8 @@ public class KeyAttestationExample {
     printOptional(authorizationList.attestationIdModel, indent + "Attestation ID Model");
     printOptional(authorizationList.vendorPatchLevel, indent + "Vendor Patch Level");
     printOptional(authorizationList.bootPatchLevel, indent + "Boot Patch Level");
+    System.out.println(
+        indent + "Identity Credential Key: " + authorizationList.identityCredentialKey);
   }
 
   private static void printRootOfTrust(Optional<RootOfTrust> rootOfTrust, String indent) {

--- a/server/src/main/java/com/google/android/attestation/AuthorizationList.java
+++ b/server/src/main/java/com/google/android/attestation/AuthorizationList.java
@@ -37,6 +37,7 @@ import static com.google.android.attestation.Constants.KM_TAG_AUTH_TIMEOUT;
 import static com.google.android.attestation.Constants.KM_TAG_BOOT_PATCH_LEVEL;
 import static com.google.android.attestation.Constants.KM_TAG_CREATION_DATE_TIME;
 import static com.google.android.attestation.Constants.KM_TAG_DEVICE_UNIQUE_ATTESTATION;
+import static com.google.android.attestation.Constants.KM_TAG_IDENTITY_CREDENTIAL_KEY;
 import static com.google.android.attestation.Constants.KM_TAG_DIGEST;
 import static com.google.android.attestation.Constants.KM_TAG_EC_CURVE;
 import static com.google.android.attestation.Constants.KM_TAG_KEY_SIZE;
@@ -136,6 +137,7 @@ public class AuthorizationList {
   public final Optional<Integer> vendorPatchLevel;
   public final Optional<Integer> bootPatchLevel;
   public final boolean individualAttestation;
+  public final boolean identityCredentialKey;
 
   private AuthorizationList(ASN1Encodable[] authorizationList, int attestationVersion) {
     Map<Integer, ASN1Primitive> authorizationMap = getAuthorizationMap(authorizationList);
@@ -221,6 +223,9 @@ public class AuthorizationList {
         findOptionalIntegerAuthorizationListEntry(authorizationMap, KM_TAG_BOOT_PATCH_LEVEL);
     this.individualAttestation =
         findBooleanAuthorizationListEntry(authorizationMap, KM_TAG_DEVICE_UNIQUE_ATTESTATION);
+    this.identityCredentialKey =
+        findBooleanAuthorizationListEntry(authorizationMap, KM_TAG_IDENTITY_CREDENTIAL_KEY);
+
   }
 
   private AuthorizationList(Builder builder) {

--- a/server/src/main/java/com/google/android/attestation/Constants.java
+++ b/server/src/main/java/com/google/android/attestation/Constants.java
@@ -84,6 +84,7 @@ public class Constants {
   static final int KM_TAG_VENDOR_PATCH_LEVEL = 718;
   static final int KM_TAG_BOOT_PATCH_LEVEL = 719;
   static final int KM_TAG_DEVICE_UNIQUE_ATTESTATION = 720;
+  static final int KM_TAG_IDENTITY_CREDENTIAL_KEY = 721;
   static final int ROOT_OF_TRUST_VERIFIED_BOOT_KEY_INDEX = 0;
   static final int ROOT_OF_TRUST_DEVICE_LOCKED_INDEX = 1;
   static final int ROOT_OF_TRUST_VERIFIED_BOOT_STATE_INDEX = 2;


### PR DESCRIPTION
I am using this tool to dump the attestation extensions generated by Keymint or Identity Credential and I think that it could be useful to dump the value of the Tag::IDENTITY_CREDENTIAL_KEY.