### PR TITLE
Cache status list HTTP response

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,8 @@ bin/
 build/
 gen/
 out/
+# Runtime HTTP response cache
+httpcache/
 # Local configuration file (sdk path, etc)
 local.properties
 # Eclipse project files

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -31,6 +31,7 @@ dependencies {
     compile 'com.google.errorprone:error_prone_annotations:2.3.1'
     // Gson used for decoding certificate status list
     compile 'com.google.code.gson:gson:2.8.5'
+    compile 'com.squareup.okhttp3:okhttp:4.10.0'
     // JUnit, Truth and Truth8 used for testing
     testCompile 'junit:junit:4.12'
     testCompile 'com.google.truth:truth:1.0'

--- a/server/src/main/java/com/google/android/attestation/BUILD
+++ b/server/src/main/java/com/google/android/attestation/BUILD
@@ -15,6 +15,7 @@ java_library(
         "@maven//:com_google_code_gson_gson",
         "@maven//:com_google_errorprone_error_prone_annotations",
         "@maven//:com_google_guava_guava",
+        "@maven//:com_squareup_okhttp3_okhttp",
         "@maven//:org_bouncycastle_bcpkix_jdk15on",
         "@maven//:org_bouncycastle_bcprov_jdk15on",
     ],


### PR DESCRIPTION
The status list only needs to be fetched from the server when it becomes stale according to the caching policy in the HTTP response. Import OkHttp and take advantage of its RFC correct and pragmatic caching behaviour.

The cache is stored on disk so will be reused across multiple invocations.