### PR TITLE
Adding CI script for Bazel, and support to parse second IMEI

### DIFF
--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -1,4 +1,3 @@
-
 name: Java CI with Bazel
 
 on:
@@ -7,18 +6,30 @@ on:
   pull_request:
     branches: [ "master" ]
 
-permissions:
-  contents: read
-
 jobs:
-  checks:
-    name: run
+  build:
     runs-on: ubuntu-latest
+    
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v1
 
-    - name: run
-      uses: ngalaiko/bazel-action/2.0@master
+    - name: Mount bazel cache
+      uses: actions/cache@v1
       with:
-        working_dir: server/src/main/
-        args: build //...
+        path: "/home/runner/.cache/bazel"
+        key: bazel
+
+    - name: Install bazelisk
+      run: |
+        curl -LO "https://github.com/bazelbuild/bazelisk/releases/download/v1.1.0/bazelisk-linux-amd64"
+        mkdir -p "${GITHUB_WORKSPACE}/bin/"
+        mv bazelisk-linux-amd64 "${GITHUB_WORKSPACE}/bin/bazel"
+        chmod +x "${GITHUB_WORKSPACE}/bin/bazel"
+
+    - name: Test
+      run: |
+        "${GITHUB_WORKSPACE}/bin/bazel" test //...
+
+    - name: Build
+      run: |
+        "${GITHUB_WORKSPACE}/bin/bazel" build //...

--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -1,0 +1,24 @@
+
+name: Java CI with Bazel
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+permissions:
+  contents: read
+
+jobs:
+  checks:
+    name: run
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+
+    - name: run
+      uses: ngalaiko/bazel-action/2.0@master
+      with:
+        working_dir: server/src/main/
+        args: build //...

--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -26,10 +26,10 @@ jobs:
         mv bazelisk-linux-amd64 "${GITHUB_WORKSPACE}/bin/bazel"
         chmod +x "${GITHUB_WORKSPACE}/bin/bazel"
 
-    - name: Test
-      run: |
-        "${GITHUB_WORKSPACE}/bin/bazel" test //...
-
     - name: Build
       run: |
         "${GITHUB_WORKSPACE}/bin/bazel" build //...
+
+    - name: Test
+      run: |
+        "${GITHUB_WORKSPACE}/bin/bazel" test //...

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -37,6 +37,7 @@ maven_install(
         "com.google.guava:guava:27.0.1-android",
         "com.google.errorprone:error_prone_annotations:2.3.1",
 
+        "com.squareup.okhttp3:okhttp:4.10.0",
 
         # Test libraries
         "junit:junit:4.12",

--- a/server/src/main/java/com/android/example/KeyAttestationExample.java
+++ b/server/src/main/java/com/android/example/KeyAttestationExample.java
@@ -163,6 +163,8 @@ public class KeyAttestationExample {
     printOptional(authorizationList.attestationIdProduct, indent + "Attestation ID Product");
     printOptional(authorizationList.attestationIdSerial, indent + "Attestation ID Serial");
     printOptional(authorizationList.attestationIdImei, indent + "Attestation ID IMEI");
+    printOptional(
+        authorizationList.attestationIdSecondImei, indent + "Attestation ID SECOND IMEI");
     printOptional(authorizationList.attestationIdMeid, indent + "Attestation ID MEID");
     printOptional(
         authorizationList.attestationIdManufacturer, indent + "Attestation ID Manufacturer");

--- a/server/src/main/java/com/google/android/attestation/AuthorizationList.java
+++ b/server/src/main/java/com/google/android/attestation/AuthorizationList.java
@@ -32,6 +32,7 @@ import static com.google.android.attestation.Constants.KM_TAG_ATTESTATION_ID_MAN
 import static com.google.android.attestation.Constants.KM_TAG_ATTESTATION_ID_MEID;
 import static com.google.android.attestation.Constants.KM_TAG_ATTESTATION_ID_MODEL;
 import static com.google.android.attestation.Constants.KM_TAG_ATTESTATION_ID_PRODUCT;
+import static com.google.android.attestation.Constants.KM_TAG_ATTESTATION_ID_SECOND_IMEI;
 import static com.google.android.attestation.Constants.KM_TAG_ATTESTATION_ID_SERIAL;
 import static com.google.android.attestation.Constants.KM_TAG_AUTH_TIMEOUT;
 import static com.google.android.attestation.Constants.KM_TAG_BOOT_PATCH_LEVEL;
@@ -131,6 +132,7 @@ public class AuthorizationList {
   public final Optional<byte[]> attestationIdProduct;
   public final Optional<byte[]> attestationIdSerial;
   public final Optional<byte[]> attestationIdImei;
+  public final Optional<byte[]> attestationIdSecondImei;
   public final Optional<byte[]> attestationIdMeid;
   public final Optional<byte[]> attestationIdManufacturer;
   public final Optional<byte[]> attestationIdModel;
@@ -210,6 +212,8 @@ public class AuthorizationList {
         findOptionalByteArrayAuthorizationListEntry(authorizationMap, KM_TAG_ATTESTATION_ID_SERIAL);
     this.attestationIdImei =
         findOptionalByteArrayAuthorizationListEntry(authorizationMap, KM_TAG_ATTESTATION_ID_IMEI);
+    this.attestationIdSecondImei =
+            findOptionalByteArrayAuthorizationListEntry(authorizationMap, KM_TAG_ATTESTATION_ID_SECOND_IMEI);
     this.attestationIdMeid =
         findOptionalByteArrayAuthorizationListEntry(authorizationMap, KM_TAG_ATTESTATION_ID_MEID);
     this.attestationIdManufacturer =
@@ -262,6 +266,7 @@ public class AuthorizationList {
     this.attestationIdProduct = Optional.ofNullable(builder.attestationIdProduct);
     this.attestationIdSerial = Optional.ofNullable(builder.attestationIdSerial);
     this.attestationIdImei = Optional.ofNullable(builder.attestationIdImei);
+    this.attestationIdSecondImei = Optional.ofNullable(builder.attestationIdSecondImei);
     this.attestationIdMeid = Optional.ofNullable(builder.attestationIdMeid);
     this.attestationIdManufacturer = Optional.ofNullable(builder.attestationIdManufacturer);
     this.attestationIdModel = Optional.ofNullable(builder.attestationIdModel);
@@ -435,6 +440,7 @@ public class AuthorizationList {
     addOptionalOctetString(KM_TAG_ATTESTATION_ID_PRODUCT, this.attestationIdProduct, vector);
     addOptionalOctetString(KM_TAG_ATTESTATION_ID_SERIAL, this.attestationIdSerial, vector);
     addOptionalOctetString(KM_TAG_ATTESTATION_ID_IMEI, this.attestationIdImei, vector);
+    addOptionalOctetString(KM_TAG_ATTESTATION_ID_SECOND_IMEI, this.attestationIdSecondImei, vector);
     addOptionalOctetString(KM_TAG_ATTESTATION_ID_MEID, this.attestationIdMeid, vector);
     addOptionalOctetString(
         KM_TAG_ATTESTATION_ID_MANUFACTURER, this.attestationIdManufacturer, vector);
@@ -551,6 +557,7 @@ public class AuthorizationList {
     byte[] attestationIdProduct;
     byte[] attestationIdSerial;
     byte[] attestationIdImei;
+    byte[] attestationIdSecondImei;
     byte[] attestationIdMeid;
     byte[] attestationIdManufacturer;
     byte[] attestationIdModel;
@@ -754,6 +761,12 @@ public class AuthorizationList {
     @CanIgnoreReturnValue
     public Builder setAttestationIdImei(byte[] attestationIdImei) {
       this.attestationIdImei = attestationIdImei;
+      return this;
+    }
+
+    @CanIgnoreReturnValue
+    public Builder setAttestationIdSecondImei(byte[] attestationIdSecondImei) {
+      this.attestationIdSecondImei = attestationIdSecondImei;
       return this;
     }
 

--- a/server/src/main/java/com/google/android/attestation/Constants.java
+++ b/server/src/main/java/com/google/android/attestation/Constants.java
@@ -85,6 +85,7 @@ public class Constants {
   static final int KM_TAG_BOOT_PATCH_LEVEL = 719;
   static final int KM_TAG_DEVICE_UNIQUE_ATTESTATION = 720;
   static final int KM_TAG_IDENTITY_CREDENTIAL_KEY = 721;
+  static final int KM_TAG_ATTESTATION_ID_SECOND_IMEI = 723;
   static final int ROOT_OF_TRUST_VERIFIED_BOOT_KEY_INDEX = 0;
   static final int ROOT_OF_TRUST_DEVICE_LOCKED_INDEX = 1;
   static final int ROOT_OF_TRUST_VERIFIED_BOOT_STATE_INDEX = 2;


### PR DESCRIPTION
- Added CI script to build and test using bazel build files.
- Added a support to parse Second IMEI from an attested certificate.
- fixed the problem of bazel build after merging okhttp dependency.