### PR TITLE
Make unorderedTags an instance variable

### DIFF
--- a/server/src/main/java/com/google/android/attestation/AuthorizationList.java
+++ b/server/src/main/java/com/google/android/attestation/AuthorizationList.java
@@ -372,9 +372,10 @@ public class AuthorizationList {
   public final Optional<Integer> bootPatchLevel;
   public final boolean individualAttestation;
   public final boolean identityCredentialKey;
+  public final ImmutableList<Integer> unorderedTags;
 
   private AuthorizationList(ASN1Encodable[] authorizationList, int attestationVersion) {
-    parsedAuthorizationMap = getAuthorizationMap(authorizationList);
+    ParsedAuthorizationMap parsedAuthorizationMap = getAuthorizationMap(authorizationList);
 
     this.purpose =
         parsedAuthorizationMap.findIntegerSetAuthorizationListEntry(KM_TAG_PURPOSE).stream()
@@ -493,6 +494,7 @@ public class AuthorizationList {
         parsedAuthorizationMap.findBooleanAuthorizationListEntry(KM_TAG_DEVICE_UNIQUE_ATTESTATION);
     this.identityCredentialKey =
         parsedAuthorizationMap.findBooleanAuthorizationListEntry(KM_TAG_IDENTITY_CREDENTIAL_KEY);
+    this.unorderedTags = parsedAuthorizationMap.getUnorderedTags();
   }
 
   private AuthorizationList(Builder builder) {
@@ -537,6 +539,7 @@ public class AuthorizationList {
     this.bootPatchLevel = Optional.ofNullable(builder.bootPatchLevel);
     this.individualAttestation = builder.individualAttestation;
     this.identityCredentialKey = builder.identityCredentialKey;
+    this.unorderedTags = builder.unorderedTags;
   }
 
   static AuthorizationList createAuthorizationList(
@@ -814,6 +817,7 @@ public class AuthorizationList {
     Integer bootPatchLevel;
     boolean individualAttestation;
     boolean identityCredentialKey;
+    ImmutableList<Integer> unorderedTags;
 
     @CanIgnoreReturnValue
     public Builder setPurpose(Set<OperationPurpose> purpose) {
@@ -1064,13 +1068,6 @@ public class AuthorizationList {
     public AuthorizationList build() {
       return new AuthorizationList(this);
     }
-  }
-
-  /** Holds authorizations map and unordered tags in authorization list present in attest record. */
-  private ParsedAuthorizationMap parsedAuthorizationMap;
-
-  public ImmutableList<Integer> getUnorderedTags() {
-    return parsedAuthorizationMap.getUnorderedTags();
   }
 
   /**

--- a/server/src/test/java/com/google/android/attestation/AuthorizationListTest.java
+++ b/server/src/test/java/com/google/android/attestation/AuthorizationListTest.java
@@ -105,7 +105,7 @@ public class AuthorizationListTest {
         AuthorizationList.createAuthorizationList(
             getEncodableAuthorizationList(SW_ENFORCED_EXTENSION_DATA), ATTESTATION_VERSION);
 
-    assertThat(authorizationList.getUnorderedTags()).isEmpty();
+    assertThat(authorizationList.unorderedTags).isEmpty();
     assertThat(authorizationList.creationDateTime).hasValue(EXPECTED_SW_CREATION_DATETIME);
     assertThat(authorizationList.rootOfTrust).isEmpty();
     assertThat(authorizationList.attestationApplicationId).isPresent();
@@ -121,7 +121,7 @@ public class AuthorizationListTest {
         AuthorizationList.createAuthorizationList(
             getEncodableAuthorizationList(TEE_ENFORCED_EXTENSION_DATA), ATTESTATION_VERSION);
 
-    assertThat(authorizationList.getUnorderedTags()).isEmpty();
+    assertThat(authorizationList.unorderedTags).isEmpty();
     assertThat(authorizationList.purpose).isEqualTo(EXPECTED_TEE_PURPOSE);
     assertThat(authorizationList.algorithm).hasValue(EXPECTED_TEE_ALGORITHM);
     assertThat(authorizationList.keySize).hasValue(EXPECTED_TEE_KEY_SIZE);
@@ -170,7 +170,7 @@ public class AuthorizationListTest {
             getEncodableAuthorizationList(EXTENTION_DATA_WITH_INDIVIDUAL_ATTESTATION),
             ATTESTATION_VERSION);
 
-    assertThat(authorizationList.getUnorderedTags()).isEmpty();
+    assertThat(authorizationList.unorderedTags).isEmpty();
     assertThat(authorizationList.individualAttestation).isTrue();
   }
 
@@ -185,11 +185,11 @@ public class AuthorizationListTest {
   @Test
   public void testCanParseIdentityCredentialTag() throws IOException {
     AuthorizationList authorizationList =
-            AuthorizationList.createAuthorizationList(
-                    getEncodableAuthorizationList(EXTENTION_DATA_WITH_ID_CREDENTIAL_KEY),
-                    ATTESTATION_VERSION);
+        AuthorizationList.createAuthorizationList(
+            getEncodableAuthorizationList(EXTENTION_DATA_WITH_ID_CREDENTIAL_KEY),
+            ATTESTATION_VERSION);
 
-    assertThat(authorizationList.getUnorderedTags()).isEmpty();
+    assertThat(authorizationList.unorderedTags).isEmpty();
     assertThat(authorizationList.identityCredentialKey).isTrue();
   }
 
@@ -200,7 +200,7 @@ public class AuthorizationListTest {
             getEncodableAuthorizationList(EXTENTION_DATA_WITH_INDIVIDUAL_ATTESTATION),
             ATTESTATION_VERSION);
     ASN1Sequence seq = authorizationList.toAsn1Sequence();
-    assertThat(authorizationList.getUnorderedTags()).isEmpty();
+    assertThat(authorizationList.unorderedTags).isEmpty();
     assertThat(seq.getEncoded("DER"))
         .isEqualTo(Base64.decode(EXTENTION_DATA_WITH_INDIVIDUAL_ATTESTATION));
   }
@@ -219,8 +219,7 @@ public class AuthorizationListTest {
     AuthorizationList authorizationList =
         AuthorizationList.createAuthorizationList(encodableAuthList, ATTESTATION_VERSION);
     // Make sure there is unordered tag present.
-    assertThat(authorizationList.getUnorderedTags()).hasSize(1);
-    assertThat(authorizationList.getUnorderedTags()).contains(taggedEntry.getTagNo());
+    assertThat(authorizationList.unorderedTags).containsExactly(taggedEntry.getTagNo());
   }
 
   @Test


### PR DESCRIPTION
Restores the value class semantics of AuthorizationList and allows ParsedAuthorizationMap to be freed after use.