### PR TITLE
Make attestationApplicationId field not optional

### DIFF
--- a/server/src/main/java/com/android/example/KeyAttestationExample.java
+++ b/server/src/main/java/com/android/example/KeyAttestationExample.java
@@ -153,13 +153,8 @@ public class KeyAttestationExample {
             });
     print(authorizationList.osVersion(), indent + "OS Version");
     print(authorizationList.osPatchLevel(), indent + "OS Patch Level");
-    authorizationList
-        .attestationApplicationId()
-        .ifPresent(
-            attestationApplicationId -> {
-              System.out.println(indent + "Attestation Application ID:");
-              print(attestationApplicationId, indent + "\t");
-            });
+    System.out.println(indent + "Attestation Application ID:");
+    print(authorizationList.attestationApplicationId(), indent + "\t");
     print(authorizationList.attestationIdBrand(), indent + "Attestation ID Brand");
     print(authorizationList.attestationIdDevice(), indent + "Attestation ID Device");
     print(authorizationList.attestationIdProduct(), indent + "Attestation ID Product");

--- a/server/src/main/java/com/google/android/attestation/AttestationApplicationId.java
+++ b/server/src/main/java/com/google/android/attestation/AttestationApplicationId.java
@@ -28,6 +28,7 @@ import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import com.google.errorprone.annotations.Immutable;
 import com.google.protobuf.ByteString;
 import java.io.IOException;
+import java.util.Optional;
 import java.util.Set;
 import org.bouncycastle.asn1.ASN1Encodable;
 import org.bouncycastle.asn1.ASN1Integer;
@@ -112,7 +113,10 @@ public abstract class AttestationApplicationId {
     return builder.build();
   }
 
-  byte[] getEncoded() {
+  Optional<byte[]> getEncoded() {
+    if (packageInfos().isEmpty() && signatureDigests().isEmpty()) {
+      return Optional.empty();
+    }
     ASN1Encodable[] applicationIdAsn1Array = new ASN1Encodable[2];
     applicationIdAsn1Array[ATTESTATION_APPLICATION_ID_PACKAGE_INFOS_INDEX] =
         new DERSet(
@@ -127,7 +131,7 @@ public abstract class AttestationApplicationId {
                 .toArray(DEROctetString[]::new));
 
     try {
-      return new DERSequence(applicationIdAsn1Array).getEncoded();
+      return Optional.of(new DERSequence(applicationIdAsn1Array).getEncoded());
     } catch (IOException e) {
       throw new IllegalArgumentException(e);
     }

--- a/server/src/main/java/com/google/android/attestation/AuthorizationList.java
+++ b/server/src/main/java/com/google/android/attestation/AuthorizationList.java
@@ -392,7 +392,7 @@ public abstract class AuthorizationList {
 
   public abstract Optional<YearMonth> osPatchLevel();
 
-  public abstract Optional<AttestationApplicationId> attestationApplicationId();
+  public abstract AttestationApplicationId attestationApplicationId();
 
   public abstract Optional<ByteString> attestationIdBrand();
 
@@ -433,7 +433,8 @@ public abstract class AuthorizationList {
         .setAllApplications(false)
         .setRollbackResistant(false)
         .setIndividualAttestation(false)
-        .setIdentityCredentialKey(false);
+        .setIdentityCredentialKey(false)
+        .setAttestationApplicationId(AttestationApplicationId.builder().build());
   }
 
   /**
@@ -905,7 +906,7 @@ public abstract class AuthorizationList {
         this.osPatchLevel().map(AuthorizationList::toString).map(Integer::valueOf),
         vector);
     this.attestationApplicationId()
-        .map(AttestationApplicationId::getEncoded)
+        .getEncoded()
         .map(DEROctetString::new)
         .map(obj -> new DERTaggedObject(KM_TAG_ATTESTATION_APPLICATION_ID, obj))
         .ifPresent(vector::add);

--- a/server/src/test/java/com/google/android/attestation/AuthorizationListTest.java
+++ b/server/src/test/java/com/google/android/attestation/AuthorizationListTest.java
@@ -15,7 +15,6 @@
 
 package com.google.android.attestation;
 
-import static com.google.android.attestation.AuthorizationList.toLocalDate;
 import static com.google.android.attestation.AuthorizationList.DigestMode.SHA_2_256;
 import static com.google.android.attestation.AuthorizationList.OperationPurpose.SIGN;
 import static com.google.android.attestation.AuthorizationList.OperationPurpose.VERIFY;
@@ -25,6 +24,7 @@ import static com.google.android.attestation.AuthorizationList.UserAuthType.FING
 import static com.google.android.attestation.AuthorizationList.UserAuthType.PASSWORD;
 import static com.google.android.attestation.AuthorizationList.UserAuthType.USER_AUTH_TYPE_ANY;
 import static com.google.android.attestation.AuthorizationList.UserAuthType.USER_AUTH_TYPE_NONE;
+import static com.google.android.attestation.AuthorizationList.toLocalDate;
 import static com.google.android.attestation.AuthorizationList.userAuthTypeToEnum;
 import static com.google.android.attestation.Constants.UINT32_MAX;
 import static com.google.common.truth.Truth.assertThat;
@@ -116,7 +116,7 @@ public class AuthorizationListTest {
     assertThat(authorizationList.creationDateTime()).hasValue(EXPECTED_SW_CREATION_DATETIME);
     assertThat(authorizationList.rootOfTrust()).isEmpty();
     assertThat(authorizationList.attestationApplicationId())
-        .hasValue(EXPECTED_SW_ATTESTATION_APPLICATION_ID);
+        .isEqualTo(EXPECTED_SW_ATTESTATION_APPLICATION_ID);
     assertThat(authorizationList.individualAttestation()).isFalse();
     assertThat(authorizationList.identityCredentialKey()).isFalse();
   }


### PR DESCRIPTION
The AttestationApplicationId class contains two sets, which already convey presence. This change makes the Java API cleaner at the expense of the marshalling code being marginally more complex.