### PR TITLE
Remove deprecated ROLLBACK_RESISTANT tag

### DIFF
--- a/src/main/java/com/android/example/KeyAttestationExample.java
+++ b/src/main/java/com/android/example/KeyAttestationExample.java
@@ -141,7 +141,6 @@ public class KeyAttestationExample {
         indent + "Unlocked Device Required: " + authorizationList.unlockedDeviceRequired());
     print(authorizationList.creationDateTime(), indent + "Creation DateTime");
     print(authorizationList.origin(), indent + "Origin");
-    System.out.println(indent + "Rollback Resistant: " + authorizationList.rollbackResistant());
     authorizationList
         .rootOfTrust()
         .ifPresent(

--- a/src/main/java/com/google/android/attestation/AuthorizationList.java
+++ b/src/main/java/com/google/android/attestation/AuthorizationList.java
@@ -47,7 +47,6 @@ import static com.google.android.attestation.Constants.KM_TAG_OS_VERSION;
 import static com.google.android.attestation.Constants.KM_TAG_PADDING;
 import static com.google.android.attestation.Constants.KM_TAG_PURPOSE;
 import static com.google.android.attestation.Constants.KM_TAG_ROLLBACK_RESISTANCE;
-import static com.google.android.attestation.Constants.KM_TAG_ROLLBACK_RESISTANT;
 import static com.google.android.attestation.Constants.KM_TAG_ROOT_OF_TRUST;
 import static com.google.android.attestation.Constants.KM_TAG_RSA_PUBLIC_EXPONENT;
 import static com.google.android.attestation.Constants.KM_TAG_TRUSTED_CONFIRMATION_REQUIRED;
@@ -377,8 +376,6 @@ public abstract class AuthorizationList {
 
   public abstract Optional<KeyOrigin> origin();
 
-  public abstract boolean rollbackResistant();
-
   public abstract Optional<RootOfTrust> rootOfTrust();
 
   public abstract Optional<Integer> osVersion();
@@ -422,7 +419,6 @@ public abstract class AuthorizationList {
         .setTrustedUserPresenceRequired(false)
         .setTrustedConfirmationRequired(false)
         .setUnlockedDeviceRequired(false)
-        .setRollbackResistant(false)
         .setIndividualAttestation(false);
   }
 
@@ -495,8 +491,6 @@ public abstract class AuthorizationList {
     public abstract Builder setCreationDateTime(Instant creationDateTime);
 
     public abstract Builder setOrigin(KeyOrigin origin);
-
-    public abstract Builder setRollbackResistant(boolean rollbackResistant);
 
     public abstract Builder setRootOfTrust(RootOfTrust rootOfTrust);
 
@@ -653,8 +647,6 @@ public abstract class AuthorizationList {
         .findOptionalIntegerAuthorizationListEntry(KM_TAG_ORIGIN)
         .map(ASN1_TO_KEY_ORIGIN::get)
         .ifPresent(builder::setOrigin);
-    builder.setRollbackResistant(
-        parsedAuthorizationMap.findBooleanAuthorizationListEntry(KM_TAG_ROLLBACK_RESISTANT));
     parsedAuthorizationMap
         .findAuthorizationListEntry(KM_TAG_ROOT_OF_TRUST)
         .map(ASN1Sequence.class::cast)
@@ -867,7 +859,6 @@ public abstract class AuthorizationList {
     addBoolean(KM_TAG_UNLOCKED_DEVICE_REQUIRED, this.unlockedDeviceRequired(), vector);
     addOptionalInstant(KM_TAG_CREATION_DATE_TIME, this.creationDateTime(), vector);
     addOptionalInteger(KM_TAG_ORIGIN, this.origin().map(KEY_ORIGIN_TO_ASN1::get), vector);
-    addBoolean(KM_TAG_ROLLBACK_RESISTANT, this.rollbackResistant(), vector);
     addOptionalRootOfTrust(KM_TAG_ROOT_OF_TRUST, this.rootOfTrust(), vector);
     addOptionalInteger(KM_TAG_OS_VERSION, this.osVersion(), vector);
     addOptionalInteger(

--- a/src/main/java/com/google/android/attestation/Constants.java
+++ b/src/main/java/com/google/android/attestation/Constants.java
@@ -66,7 +66,6 @@ public class Constants {
   public static final int KM_TAG_UNLOCKED_DEVICE_REQUIRED = 509;
   public static final int KM_TAG_CREATION_DATE_TIME = 701;
   public static final int KM_TAG_ORIGIN = 702;
-  public static final int KM_TAG_ROLLBACK_RESISTANT = 703;
   public static final int KM_TAG_ROOT_OF_TRUST = 704;
   public static final int KM_TAG_OS_VERSION = 705;
   public static final int KM_TAG_OS_PATCH_LEVEL = 706;


### PR DESCRIPTION
This tag was removed in Keymaster 4.0 and has been replaced by the `ROLLBACK_RESISTANCE` tag.