### PR TITLE
Add toBuilder() methods for types with builders

### DIFF
--- a/src/main/java/com/google/android/attestation/AttestationApplicationId.java
+++ b/src/main/java/com/google/android/attestation/AttestationApplicationId.java
@@ -52,6 +52,8 @@ public abstract class AttestationApplicationId {
 
   public abstract ImmutableSet<ByteString> signatureDigests();
 
+  public abstract Builder toBuilder();
+
   public static Builder builder() {
     return new AutoValue_AttestationApplicationId.Builder();
   }

--- a/src/main/java/com/google/android/attestation/AuthorizationList.java
+++ b/src/main/java/com/google/android/attestation/AuthorizationList.java
@@ -411,6 +411,8 @@ public abstract class AuthorizationList {
 
   public abstract ImmutableList<Integer> unorderedTags();
 
+  public abstract Builder toBuilder();
+
   public static Builder builder() {
     return new AutoValue_AuthorizationList.Builder()
         .setRollbackResistance(false)

--- a/src/main/java/com/google/android/attestation/ParsedAttestationRecord.java
+++ b/src/main/java/com/google/android/attestation/ParsedAttestationRecord.java
@@ -70,6 +70,8 @@ public abstract class ParsedAttestationRecord {
   @SuppressWarnings("Immutable")
   public abstract PublicKey attestedKey();
 
+  public abstract Builder toBuilder();
+
   public static Builder builder() {
     return new AutoValue_ParsedAttestationRecord.Builder()
         .setAttestationChallenge(ByteString.EMPTY)

--- a/src/main/java/com/google/android/attestation/RootOfTrust.java
+++ b/src/main/java/com/google/android/attestation/RootOfTrust.java
@@ -50,6 +50,8 @@ public abstract class RootOfTrust {
 
   public abstract Optional<ByteString> verifiedBootHash();
 
+  public abstract Builder toBuilder();
+
   public static Builder builder() {
     return new AutoValue_RootOfTrust.Builder()
         .setVerifiedBootKey(ByteString.EMPTY)

--- a/src/test/java/com/google/android/attestation/AttestationApplicationIdTest.java
+++ b/src/test/java/com/google/android/attestation/AttestationApplicationIdTest.java
@@ -127,4 +127,11 @@ public class AttestationApplicationIdTest {
             AttestationApplicationId.createAttestationApplicationId(
                 "Invalid DEROctet String".getBytes(UTF_8)));
   }
+
+  @Test
+  public void testBuildAttestationApplicationId() {
+    byte[] encoded = EXPECTED_ATTESTATION_APPLICATION_ID.getEncoded();
+
+    assertThat(encoded).isEqualTo(ATTESTATION_APPLICATION_ID);
+  }
 }

--- a/src/test/java/com/google/android/attestation/RootOfTrustTest.java
+++ b/src/test/java/com/google/android/attestation/RootOfTrustTest.java
@@ -68,4 +68,36 @@ public class RootOfTrustTest {
     assertThrows(
         NullPointerException.class, () -> RootOfTrust.createRootOfTrust(null, ATTESTATION_VERSION));
   }
+
+  @Test
+  public void testBuildRootOfTrust() throws IOException {
+    RootOfTrust rootOfTrust = RootOfTrust.builder()
+        .setVerifiedBootKey(EXPECTED_VERIFIED_BOOT_KEY)
+        .setDeviceLocked(EXPECTED_DEVICE_LOCKED)
+        .setVerifiedBootState(EXPECTED_VERIFIED_BOOT_STATE)
+        .setVerifiedBootHash(EXPECTED_VERIFIED_BOOT_HASH)
+        .build();
+
+    ASN1Sequence rootOfTrustSequence = rootOfTrust.toAsn1Sequence();
+    String rootOfTrustB64 = Base64.getEncoder().encodeToString(rootOfTrustSequence.getEncoded());
+
+    assertThat(rootOfTrustB64).isEqualTo(ROOT_OF_TRUST);
+  }
+
+  @Test
+  public void testBuildAndCreateRootOfTrust() throws IOException {
+    ByteString key = ByteString.copyFromUtf8("my boot key");
+    ByteString hash = ByteString.copyFromUtf8("my boot hash");
+    RootOfTrust expected = RootOfTrust.builder()
+        .setVerifiedBootKey(key)
+        .setDeviceLocked(true)
+        .setVerifiedBootState(VerifiedBootState.VERIFIED)
+        .setVerifiedBootHash(hash)
+        .build();
+
+    RootOfTrust actual =
+        RootOfTrust.createRootOfTrust(expected.toAsn1Sequence(), ATTESTATION_VERSION);
+
+    assertThat(actual).isEqualTo(expected);
+  }
 }


### PR DESCRIPTION
Add tests to make sure all buildable classes have some coverage of encoding methods.